### PR TITLE
Describe CLA signature process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# JanusGraph legal documents
+
+Before you can contribute to JanusGraph, please sign the Contributor License
+Agreement (CLA). This is not a copyright *assignment*, it simply gives the
+JanusGraph project the permission and license to use and redistribute your
+contributions as part of the project.
+
+* If you are an individual writing original source code and you're sure you own
+  the intellectual property, then you'll need to sign an
+  [individual CLA](https://github.com/JanusGraph/legal/blob/master/JanusGraph_ICLA_1.0.pdf).
+
+* If you work for a company or another organization that may have claim to
+  intellectual property you may produce, and the organization wants to allow you
+  to contribute your work, then an authorized representative of the organization
+  will need to sign a
+  [corporate CLA](https://github.com/JanusGraph/legal/blob/master/JanusGraph_CCLA_1.0.pdf).
+
+**IMPORTANT:** DO NOT submit a pull request to this repo to sign the CLA. At
+this time, signing the CLA at this time involves filling out the ICLA or CCLA
+paperwork, scanning it in, and sending it to janusgraph-cla@googlegroups.com .
+
+Whether you sign the CCLA or the ICLA, for each contributor, please include:
+
+* the full name
+* your email address
+* your GitHub user id
+
+Be sure to also configure your local GitHub clone to match the name and email
+address in your CLA. See instructions below for details.
+
+For now, the process is manual; in the future, we hope to have an electronic
+method for CLA signatures which will be much easier to manage.


### PR DESCRIPTION
Having this in a single place will let us easily reference it from all other
repos without having to duplicate material. It also serves to document this repo
locally so that folks who come across it directly know what purpose it serves
and who to work with JanusGraph.

This brings the content over from [`JanusGraph/janusgraph/CONTRIBUTING.md`](https://github.com/JanusGraph/janusgraph/blob/master/CONTRIBUTING.md).

Signed-off-by: Misha Brukman <mbrukman@google.com>