### PR TITLE
Extend Amazon CCLA to cover @mrodaitis

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -78,6 +78,9 @@ companies:
       - name: Alexander Patrikalakis
         email: amcp@amazon.co.jp
         github: amcp
+      - name: Michael Rodaitis
+        email: rodaitis@amazon.com
+        github: mrodaitis
 
   - name: Expero
     people:


### PR DESCRIPTION
Added per email from Amazon CCLA administrators.

Welcome to JanusGraph, @mrodaitis!