### PR TITLE
Add alternate email address for @myhrvold

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -295,6 +295,10 @@ companies:
       - name: Conor Myhrvold
         email: conor@uber.com
         github: myhrvold
+      # Alternate email address for the above to handle GitHub web UI changes
+      - name: Conor Myhrvold
+        email: myhrvold@users.noreply.github.com
+        github: myhrvold
       - name: Davide Bolcioni
         email: dbolcion@uber.com
         github: dbolcioni


### PR DESCRIPTION
@myhrvold, did I guess correctly that you used the GitHub web UI to make your change in https://github.com/JanusGraph/legal/pull/41?

If so, I propose adding your email address here to make that workflow easier; sounds like we'll be adding this for several folks, and might potentially need to make this into a special case to handle the general problem better for everyone automatically.