### PR TITLE
Add default emails for @amcp and @jerryjch

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -85,9 +85,13 @@ companies:
       # CLA Manager
       - name: Brandi Duffy
         email: brandis@amazon.com
-        github: brandis 
+        github: brandis
       - name: Alexander Patrikalakis
         email: amcp@amazon.co.jp
+        github: amcp
+      # Default email used for merges via GitHub web UI.
+      - name: Alexander Patrikalakis
+        email: amcp@mit.edu
         github: amcp
       - name: Michael Rodaitis
         email: rodaitis@amazon.com
@@ -107,7 +111,7 @@ companies:
       - name: Ted Wilmes
         email: ted.wilmes@experoinc.com
         github: twilmes
-      # Ted's default email address is automatically used for merges via GitHub web UI.
+      # Default email used for merges via GitHub web UI.
       - name: Ted Wilmes
         email: twilmes@gmail.com
         github: twilmes
@@ -188,6 +192,10 @@ companies:
         github: pluradj
       - name: Jerry He
         email: jinghe@us.ibm.com
+        github: jerryjch
+      # Default email used for merges via GitHub web UI.
+      - name: Jerry He
+        email: jerryjch@apache.org
         github: jerryjch
       - name: Scott McQuillan
         email: scott.mcquillan@uk.ibm.com


### PR DESCRIPTION
When performing a merge via GitHub's web UI, the commit uses the user's default
email address in their profile, which may not be the same one as what is in
their CLA, which causes a future branch merge (second-order merge) to fail with
a `cla: no` label since the commit author is no longer on the CLA.

This change addresses the situation by adding alternate email addresses for the
users affected by this recently in https://github.com/JanusGraph/janusgraph/pull/393