### PR TITLE
Fix @myhrvold's name to match GitHub account

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -311,7 +311,7 @@ companies:
         email: conor@uber.com
         github: myhrvold
       # Alternate email address for the above to handle GitHub web UI changes
-      - name: Conor Myhrvold
+      - name: Conor L. Myhrvold
         email: myhrvold@users.noreply.github.com
         github: myhrvold
       - name: Davide Bolcioni


### PR DESCRIPTION
Exact name and email in the CLA must match that of the patch:
https://github.com/JanusGraph/legal/pull/41.patch
or the CLA bot is not happy and marks the commit, and hence the PR, as
non-conformant to the signed CLAs on file.

Longer term, the more elegant way to handle this in the `CLA_SIGNERS.yaml` file
will be to add alternate names and email addresses for everyone to make this
process easier.

This ought to fix the CLA tag on PR #41.