### PR TITLE
Add Newforma per offline-signed CCLA.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -325,6 +325,24 @@ companies:
         email: michael.figuiere@gmail.com
         github: mfiguiere
 
+  # Note: Newforma signed a CCLA but we did not get a complete list of emails
+  # and GitHub usernames for everyone. This list is thus incomplete, and will be
+  # updated when additional information is provided. Until then, the contributor
+  # below with complete information will have their PRs validated appropriately.
+  - name: Newforma
+    people:
+      # CLA Manager
+      # - name: Tammy Tenney
+      # CLA Manager
+      # - name: Patrick Filion
+      - name: Nikolai Grigoriev
+        email: ngrigoriev@gmail.com
+        github: ngrigoriev
+      # - name: Nikita Kayurov
+      # - name: Pascal Groulx
+      # - name: Valery Viceneanschi
+      # - name: Doug Cox
+
   - name: Orchestral Developments
     people:
       - name: Paul Kendall


### PR DESCRIPTION
Since we don't have complete information for every person on the list, they are
added but commented out. One person has complete information on file, so he is
added to enable verification of his PRs which are already on GitHub, waiting for
review.

@ngrigoriev and Newforma team – welcome to the JanusGraph project!