### PR TITLE
Add emails and GitHub ids for Newforma folks.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -325,23 +325,36 @@ companies:
         email: michael.figuiere@gmail.com
         github: mfiguiere
 
-  # Note: Newforma signed a CCLA but we did not get a complete list of emails
-  # and GitHub usernames for everyone. This list is thus incomplete, and will be
-  # updated when additional information is provided. Until then, the contributor
-  # below with complete information will have their PRs validated appropriately.
   - name: Newforma
     people:
       # CLA Manager
-      # - name: Tammy Tenney
+      - name: Tammy Tenney
+        email: ttenney@newforma.com
+        github: <missing>
       # CLA Manager
-      # - name: Patrick Filion
+      - name: Patrick Filion
+        email: pfilion@newforma.com
+        github: pfilion
+      - name: Nikolai Grigoriev
+        email: ngrigoriev@newforma.com
+        github: ngrigoriev
+      # Should be phased out in the future; Newforma requested use of
+      # @newforma.com email addresses for all employee contributions.
       - name: Nikolai Grigoriev
         email: ngrigoriev@gmail.com
         github: ngrigoriev
-      # - name: Nikita Kayurov
-      # - name: Pascal Groulx
-      # - name: Valery Viceneanschi
-      # - name: Doug Cox
+      - name: Nikita Kayurov
+        email: nkayurov@newforma.com
+        github: nkayurov-newforma
+      - name: Pascal Groulx
+        email: pgroulx@newforma.com
+        github: pgxtreme
+      - name: Valeri Vicneanschi
+        email: vvicneanschi@newforma.com
+        github: vicneanschi
+      - name: Doug Cox
+        email: dcox@newforma.com
+        github: DougC-Newforma
 
   - name: Orchestral Developments
     people:


### PR DESCRIPTION
@pfilion, @ngrigoriev: I've updated Newforma email and GitHub user ids per your communication.

For @ngrigoriev, I kept his @gmail.com address while also adding his @newforma.com email address, so that the current PR is still valid from the CCLA perspective.

@ngrigoriev, please note that you can update your current in-progress PR in-place to use your corporate email address — reusing the same branch and the same PR, so no need to start from scratch — by following [these instructions][contributing-ccla].

Note that it's easier to do if the commits are squashed to a single commit on that branch (the command listed there only works on the most-recent commit on the current branch); if you want to keep it as a few logically-separate commits, you will have to update each commit separately (likely via `git rebase -i [...]`, but please check the git docs on this first), and then `git push -f`.

[contributing-ccla]: https://github.com/JanusGraph/janusgraph/blob/master/CONTRIBUTING.md#configure-your-repo-to-match-the-cla