### PR TITLE
Update Nikolai Grigoriev's email address.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -338,11 +338,6 @@ companies:
       - name: Nikolai Grigoriev
         email: ngrigoriev@newforma.com
         github: ngrigoriev
-      # Should be phased out in the future; Newforma requested use of
-      # @newforma.com email addresses for all employee contributions.
-      - name: Nikolai Grigoriev
-        email: ngrigoriev@gmail.com
-        github: ngrigoriev
       - name: Nikita Kayurov
         email: nkayurov@newforma.com
         github: nkayurov-newforma


### PR DESCRIPTION
Now that https://github.com/JanusGraph/janusgraph/pull/671 has been
updated to use @newforma.com email address, we can remove the
@gmail.com address from the CCLA for consistency.

FYI, @ngrigoriev and @pfilion.