### PR TITLE
Add Chris Pounds to Expero CCLA.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -137,6 +137,9 @@ companies:
       - name: Josh Perryman
         email: josh@experoinc.com
         github: joshpci
+      - name: Chris Pounds
+        email: chris.pounds@experoinc.com
+        github: chrislbs
 
   - name: Google
     people:


### PR DESCRIPTION
Addition per email request from Sebastian Good (@sebastiang),
CCLA manager for Expero.

Welcome to the JanusGraph project, @chrislbs!