### PR TITLE
Add Domenico Corapi to the GRAKN.AI CCLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -167,12 +167,16 @@ companies:
 
   - name: GRAKN.AI
     people:
+      # CLA Manager
       - name: Haikal Pribadi
         email: haikal@grakn.ai
         github: haikalpribadi
       - name: Borislav Iordanov
         email: borislav@haikal.ai
         github: bolerio
+      - name: Domenico Corapi
+        email: domenico@haikal.ai
+        github: pluraliseseverythings
       - name: Filipe Peliz Pinto Teixeira
         email: filipe@grakn.ai
         github: fppt


### PR DESCRIPTION
Also, marked @haikalpribadi as CLA manager. Both changes per email
request from Domenico and Haikal.

Welcome to the JanusGraph project, @pluraliseseverythings!

Note: this PR is a subset of https://github.com/JanusGraph/legal/pull/68 such that it can be marked with `[cla: yes]` so that there are no force-submits of non-CLA-approved material.