### PR TITLE
Fix email address For Domenico Corapi.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -175,7 +175,7 @@ companies:
         email: borislav@haikal.ai
         github: bolerio
       - name: Domenico Corapi
-        email: domenico@haikal.ai
+        email: domenico@grakn.ai
         github: pluraliseseverythings
       - name: Filipe Peliz Pinto Teixeira
         email: filipe@grakn.ai


### PR DESCRIPTION
Fixes email address added incorrectly by @mbrukman in
https://github.com/JanusGraph/legal/pull/70 .

This will enable submitting https://github.com/JanusGraph/legal/pull/71
once other issues with the commit (usage of full name) are addressed.