### PR TITLE
Add default name used for merge commits.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -15,6 +15,10 @@ people:
   - name: David Clement
     email: david.clement90@laposte.net
     github: davidclement90
+  # Default name/email used for GitHub merge commits in the past.
+  - name: davidclement90
+    email: david.clement90@laposte.net
+    github: davidclement90
   - name: Den Kovalevsky
     email: xdev.developer@gmail.com
     github: xdev-developer


### PR DESCRIPTION
This is evident in merges from 0.2 branch to master, e.g., via
https://github.com/JanusGraph/janusgraph/pull/724