### PR TITLE
Remove Adam Holley from IBM CCLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -285,9 +285,6 @@ companies:
       - name: Faisal Ghaffar
         email: faisalgh@ie.ibm.com
         github: fghaffar
-      - name: Adam Holley
-        email: holleya@us.ibm.com
-        github: holleyism
       - name: Susan Malaika
         email: malaika@us.ibm.com
         github: sumalaika


### PR DESCRIPTION
Adam Holley is no longer at IBM as per:
https://www.linkedin.com/in/holleyism/

FYI, @holleyism: if you'd like to contribute to JanusGraph, please ask your new employer to sign a CCLA with JanusGraph and list you as a contributor.