### PR TITLE
Remove folks who left GRAKN.AI from CCLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -191,21 +191,12 @@ companies:
       - name: Haikal Pribadi
         email: haikal@grakn.ai
         github: haikalpribadi
-      - name: Borislav Iordanov
-        email: borislav@haikal.ai
-        github: bolerio
-      - name: Domenico Corapi
-        email: domenico@grakn.ai
-        github: pluraliseseverythings
       - name: Filipe Peliz Pinto Teixeira
         email: filipe@grakn.ai
         github: fppt
       - name: Felix Chapman
         email: felix@grakn.ai
         github: aelred
-      - name: Sheldon Hall
-        email: sheldon@grakn.ai
-        github: sheldonkhall
       - name: Jason Liu
         email: jason@grakn.ai
         github: duckofyork


### PR DESCRIPTION
Namely, the following folks left GRAKN.AI and will be removed:

* Borislav Iordanov (@bolerio)
* Domenico Corapi (@pluraliseseverythings)
* Sheldon Hall (@sheldonkhall)

Folks, if you would like to continue to contribute to JanusGraph (and we hope you do!), please submit:

* a new ICLA — if you will be contributing as an individual, i.e., no company can claim ownership of your contributions, or
* a new CCLA — if you will be contributing as an employee of another company

Thank you for your contributions!