### PR TITLE
Switch to Travis CI latest image versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dist: trusty
+group: travis_latest
 sudo: false
 language: python
 


### PR DESCRIPTION
Use `group: travis_latest` instead of `dist: trusty` to pick up the
latest Travis CI image changes. The new default is `group: travis_lts`
which is equivalent to the now-deprecated `dist: trusty`.

More info in this blog post:
https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images

The same change was previously made in the main repo:
https://github.com/JanusGraph/janusgraph/pull/824