### PR TITLE
Add Adam Holley per offline-signed ICLA.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -12,6 +12,9 @@
 
 # Please keep this list sorted by name.
 people:
+  - name: Adam Holley
+    email: git@holleyism.com
+    github: holleyism
   - name: David Clement
     email: david.clement90@laposte.net
     github: davidclement90


### PR DESCRIPTION
Welcome back to the JanusGraph project, @holleyism!