### PR TITLE
Remove P. Taylor Goetz from Hortonworks CCLA.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -237,9 +237,6 @@ companies:
 
   - name: Hortonworks
     people:
-      - name: P. Taylor Goetz
-        email: ptgoetz@gmail.com
-        github: ptgoetz
       - name: Alan F. Gates
         email: alanfgates@gmail.com
         github: alanfgates


### PR DESCRIPTION
Per https://www.linkedin.com/in/ptgoetz/ he now works at EPAM and hence
cannot be covered by the Hortonworks CCLA.

@ptgoetz: if you'd like to contribute to JanusGraph going forward, please submit a new CLA — we'd love to have you continue to be involved in JanusGraph!

/cc: @alanfgates, @simonellistonball (FYI)