### PR TITLE
Updating CLA Signers from GRAKN.AI

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -222,15 +222,12 @@ companies:
       - name: Haikal Pribadi
         email: haikal@grakn.ai
         github: haikalpribadi
-      - name: Filipe Peliz Pinto Teixeira
-        email: filipe@grakn.ai
-        github: fppt
-      - name: Felix Chapman
-        email: felix@grakn.ai
-        github: aelred
-      - name: Jason Liu
-        email: jason@grakn.ai
-        github: duckofyork
+      - name: Marco Scoppetta
+        email: marco@grakn.ai
+        github: marco-scoppetta
+      - name: Ganeshwara Putra
+        email: ganesh@grakn.ai
+        github: lolski
       - name: Kasper Piskorski
         email: kasper@grakn.ai
         github: kasper-piskorski


### PR DESCRIPTION
Some of our team members have changed, and we'd like to add the new CLA signers, as we're working on upgrading Cassandra for JanusGraph.