### PR TITLE
Add Prithvi Nambiar per offline-signed ICLA.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -52,6 +52,9 @@ people:
   - name: Olivier Binda
     email: olivier.binda@wanadoo.fr
     github: Lakedaemon
+  - name: Prithvi Nambiar
+    email: prithvinambiar@gmail.com
+    github: prithvinambiar
   - name: Qiao Xiang
     email: 572469094@qq.com
     github: xiangqiao123


### PR DESCRIPTION
Welcome to the JanusGraph project, @prithvinambiar! We look forward to your contributions.