### PR TITLE
Update email address for Alexander Patrikalakis

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -131,7 +131,7 @@ companies:
         email: brandis@amazon.com
         github: brandis
       - name: Alexander Patrikalakis
-        email: amcp@amazon.co.jp
+        email: amcp@amazon.com
         github: amcp
       # Default email used for merges via GitHub web UI.
       - name: Alexander Patrikalakis


### PR DESCRIPTION
Alex relocated from Japan to the US; update email address accordingly.

This change replaces https://github.com/JanusGraph/legal/pull/106 due to
the CLA issues that PR was affected by.