### PR TITLE
Revert "Add Antriksh Shah per offline-signed ICLA"

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -15,9 +15,6 @@ people:
   - name: Adam Holley
     email: git@holleyism.com
     github: holleyism
-  - name: Antriksh Shah
-    email: shah004@gmail.com
-    github: shah-antriksh
   - name: David Clement
     email: david.clement90@laposte.net
     github: davidclement90


### PR DESCRIPTION
Reverts JanusGraph/legal#117 — this CLA has not yet been approved.