### PR TITLE
Add Alexander Patrikalakis' Japan email address.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -145,6 +145,10 @@ companies:
       - name: Alexander Patrikalakis
         email: amcp@amazon.com
         github: amcp
+      # Previous email address used while working in Japan.
+      - name: Alexander Patrikalakis
+        email: amcp@amazon.co.jp
+        github: amcp
       # Default email used for merges via GitHub web UI.
       - name: Alexander Patrikalakis
         email: amcp@mit.edu


### PR DESCRIPTION
This address was used for some of the past (and current) PRs and serves
to document that @amcp committed to the project with multiple email
addresses, all of which are valid under the CCLA.

Fixes https://github.com/JanusGraph/legal/issues/105