### PR TITLE
Update Huawei CLA Manager.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -288,9 +288,9 @@ companies:
   - name: Huawei
     people:
       # CLA Manager
-      - name: Demai Ni
-        email: nidmgg@gmail.com
-        github: nidmgh
+      - name: Minqi Zhou
+        email: zhouminqi@huawei.com
+        github: polpo1980
 
   - name: IBM
     people:


### PR DESCRIPTION
Welcome to the JanusGraph project, @polpo1980!

@nidmgh, best of luck in your new role! Please sign a new CCLA if you'd like to contribute to JanusGraph with your new company.

---

Since Demai Ni left Huawei, there are no authorized contributors left on
the Huawei CCLA nor is there a CLA Manager. This change replaces Demai
Ni with Minqi Zhou to manage the Huawei CCLA going forward.

Fixes #121.