### PR TITLE
Add Goldman Sachs team via offline-signed CCLA.

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -31,9 +31,6 @@ people:
   - name: Deng Ziming
     email: swzmdeng@163.com
     github: dengziming
-  - name: Dmitry Kovalev
-    email: dk.global@gmail.com
-    github: dk-github
   - name: Dylan Bethune-Waddell
     email: dylan.bethune.waddell@mail.utoronto.ca
     github: dylanht
@@ -227,6 +224,29 @@ companies:
       - name: Kadir Bölükbasi
         email: kdrblkbs@gmail.com
         github: kdrblkbs
+
+  - name: Goldman Sachs
+    people:
+      # CLA Manager
+      - name: George Grant
+        email: George.Grant@gs.com
+        github: gg4real
+      - name: Dmitry Kovalev
+        email: Dmitry.Kovalev@gs.com
+        github: dk-github
+      # Personal email address.
+      - name: Dmitry Kovalev
+        email: dk.global@gmail.com
+        github: dk-github
+      - name: Rohan John
+        email: Rohan.John@gs.com
+        github: rmj-github
+      - name: Sachindra Nath
+        email: Sachindra.Nath@gs.com
+        github: nathsachindra
+      - name: Prakhar Agrawal
+        email: Prakhar.x.Agrawal@gs.com
+        github: codemonk5
 
   - name: Google
     people:


### PR DESCRIPTION
This change also moves Dmitry Kovalev's earlier ICLA entry to be
included under the GS CCLA.

Welcome to the JanusGraph project,  @gg4real, @dk-github, @rmj-github, @nathsachindra and @codemonk5! We look forward to your contributions.