### PR TITLE
Add graceful support for handling empty fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,4 @@ validate:
 	$(VERB) $(CLA_SCRIPT) validate $(CLA_SIGNERS)
 
 test: validate
+	$(VERB) python -m unittest discover -p '*_test.py'

--- a/cla_signers.py
+++ b/cla_signers.py
@@ -23,9 +23,13 @@ except:
     from third_party.python import yaml
 
 
-def ParseYaml(filename):
+def ParseYamlString(data):
+    return yaml.safe_load(data)
+
+
+def ParseYamlFile(filename):
     with open(filename) as yaml_input:
-        return yaml.safe_load(yaml_input.read())
+        return ParseYamlString(yaml_input.read())
 
 
 def PrintStatistics(data):
@@ -50,7 +54,7 @@ def PrintStatistics(data):
 
     print('Total signers: %d' % total_people)
 
-def ValidateFile(data):
+def ValidateData(data):
     def ValidateAccounts(accounts):
         status_code = 0
         accounts_keys = ('name', 'email', 'github')
@@ -59,6 +63,11 @@ def ValidateFile(data):
                 status_code = 1
                 sys.stderr.write('The only allowed and required keys for people/bot accounts are: %s.\n' % str(accounts_keys))
                 sys.stderr.write('Invalid account record: %s\n\n' % account)
+            for key in accounts_keys:
+                # Covers value being either `None` or empty string.
+                if not account[key]:
+                    status_code = 2
+                    sys.stderr.write('The key "%s" is empty in account (%s)\n' % (key, account))
         return status_code
 
     status_code = 0
@@ -95,12 +104,12 @@ def main(argv):
 
     command = argv[1]
     filename = argv[2]
-    data = ParseYaml(filename)
+    data = ParseYamlFile(filename)
 
     if command == 'stats':
         sys.exit(PrintStatistics(data))
     elif command == 'validate':
-        sys.exit(ValidateFile(data))
+        sys.exit(ValidateData(data))
     else:
         sys.stderr.write('Invalid command: %s\n' % command)
         ShowSyntax(program)

--- a/cla_signers_test.py
+++ b/cla_signers_test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import cla_signers
+
+
+class ClaSignersTest(unittest.TestCase):
+
+    def _ValidateData(self, data):
+        return cla_signers.ValidateData(cla_signers.ParseYamlString(data))
+
+    def testValidData(self):
+        data = """\
+people:
+  - name: foo
+    email: bar
+    github: baz
+
+bots:
+  - name: foo1
+    email: bar1
+    github: baz1
+
+companies:
+  - name: Foo
+    people:
+     - name: foo2
+       email: bar2
+       github: baz2
+"""
+        self.assertEqual(0, self._ValidateData(data))
+
+    def testEmptyStringInvalid(self):
+        data = """\
+people:
+  - name:
+    email:
+    github:
+
+bots:
+  - name:
+    email:
+    github:
+
+companies:
+  - name:
+    people:
+     - name:
+       email:
+       github:
+"""
+        self.assertNotEqual(0, self._ValidateData(data))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Outputs a clear message to show which field(s) are empty/unspecified to
allow easily tracking down an error in the config (found while
attempting to make a change and forgetting to set a field).

This change also adds some basic tests to enable making safer changes to
the validation logic in the future, as adding a test is now as simple as
adding a new test method.