### PR TITLE
Handle errors in 'people' and 'bots' sections

### DIFF
--- a/cla_signers.py
+++ b/cla_signers.py
@@ -54,26 +54,28 @@ def PrintStatistics(data):
 
     print('Total signers: %d' % total_people)
 
-def ValidateData(data):
-    def ValidateAccounts(accounts):
-        status_code = 0
-        accounts_keys = ('name', 'email', 'github')
-        for account in accounts:
-            if not account:
-                status_code = 1
-                sys.stderr.write('Invalid empty account found\n')
-                continue
-            if sorted(account.keys()) != sorted(accounts_keys):
-                status_code = 1
-                sys.stderr.write('The only allowed and required keys for people/bot accounts are: %s.\n' % str(accounts_keys))
-                sys.stderr.write('Invalid account record: %s\n\n' % account)
-            for key in accounts_keys:
-                # Covers value being either `None` or empty string.
-                if not account[key]:
-                    status_code = 2
-                    sys.stderr.write('The key "%s" is empty in account (%s)\n' % (key, account))
-        return status_code
 
+def ValidateAccounts(accounts):
+    status_code = 0
+    accounts_keys = ('name', 'email', 'github')
+    for account in accounts:
+        if not account:
+            status_code = 1
+            sys.stderr.write('Invalid empty account found\n')
+            continue
+        if sorted(account.keys()) != sorted(accounts_keys):
+            status_code = 1
+            sys.stderr.write('The only allowed and required keys for people/bot accounts are: %s.\n' % str(accounts_keys))
+            sys.stderr.write('Invalid account record: %s\n\n' % account)
+        for key in accounts_keys:
+            # Covers value being either `None` or empty string.
+            if not account[key]:
+                status_code = 2
+                sys.stderr.write('The key "%s" is empty in account (%s)\n' % (key, account))
+    return status_code
+
+
+def ValidateData(data):
     status_code = 0
 
     if 'people' in data:

--- a/cla_signers.py
+++ b/cla_signers.py
@@ -59,6 +59,10 @@ def ValidateData(data):
         status_code = 0
         accounts_keys = ('name', 'email', 'github')
         for account in accounts:
+            if not account:
+                status_code = 1
+                sys.stderr.write('Invalid empty account found\n')
+                continue
             if sorted(account.keys()) != sorted(accounts_keys):
                 status_code = 1
                 sys.stderr.write('The only allowed and required keys for people/bot accounts are: %s.\n' % str(accounts_keys))
@@ -72,19 +76,27 @@ def ValidateData(data):
 
     status_code = 0
 
-    ValidateAccounts(data['people'])
-    ValidateAccounts(data['bots'])
+    if 'people' in data:
+        status_code = ValidateAccounts(data['people'])
+        if status_code != 0:
+            return status_code
 
-    company_keys = ('name', 'people')
-    for company in data['companies']:
-        if sorted(company.keys()) != sorted(company_keys):
-            status_code = 2
-            sys.stderr.write('The only allowed and required keys for `company` are: %s.\n' % str(company_keys))
-            sys.stderr.write('Invalid company record: %s\n\n' % company)
-            continue
-        people_status = ValidateAccounts(company['people'])
-        if people_status != 0 and status_code == 0:
-            status_code = people_status
+    if 'bots' in data:
+        status_code = ValidateAccounts(data['bots'])
+        if status_code != 0:
+            return status_code
+
+    if 'companies' in data:
+        company_keys = ('name', 'people')
+        for company in data['companies']:
+            if sorted(company.keys()) != sorted(company_keys):
+                status_code = 2
+                sys.stderr.write('The only allowed and required keys for `company` are: %s.\n' % str(company_keys))
+                sys.stderr.write('Invalid company record: %s\n\n' % company)
+                continue
+            people_status = ValidateAccounts(company['people'])
+            if people_status != 0 and status_code == 0:
+                status_code = people_status
 
     return status_code
 

--- a/cla_signers_test.py
+++ b/cla_signers_test.py
@@ -23,7 +23,36 @@ class ClaSignersTest(unittest.TestCase):
     def _ValidateData(self, data):
         return cla_signers.ValidateData(cla_signers.ParseYamlString(data))
 
-    def testValidData(self):
+    def testValidPeopleOnly(self):
+        data = """\
+people:
+  - name: foo
+    email: bar
+    github: baz
+"""
+        self.assertEqual(0, self._ValidateData(data))
+
+    def testValidBotsOnly(self):
+        data = """\
+bots:
+  - name: foo
+    email: bar
+    github: baz
+"""
+        self.assertEqual(0, self._ValidateData(data))
+
+    def testValidCompaniesOnly(self):
+        data = """\
+companies:
+  - name: Foo
+    people:
+     - name: foo2
+       email: bar2
+       github: baz2
+"""
+        self.assertEqual(0, self._ValidateData(data))
+
+    def testValidCompleteData(self):
         data = """\
 people:
   - name: foo
@@ -44,24 +73,19 @@ companies:
 """
         self.assertEqual(0, self._ValidateData(data))
 
-    def testEmptyStringInvalid(self):
+    def testPeopleSectionEmptyStringInvalid(self):
         data = """\
 people:
   - name:
     email:
     github:
+"""
+        self.assertNotEqual(0, self._ValidateData(data))
 
-bots:
-  - name:
-    email:
-    github:
-
-companies:
-  - name:
-    people:
-     - name:
-       email:
-       github:
+    def testPeopleSectionEmptyInvalid(self):
+        data = """\
+people:
+  -
 """
         self.assertNotEqual(0, self._ValidateData(data))
 


### PR DESCRIPTION
Previously, errors in the 'people' and 'bots' sections were silently ignored
because the return value from `ValidateAccounts()` were dropped. Incidentally,
it made it not possible to write concise test cases which used only 'people' or
'bots' section but without an invalid 'companies' section.

Also, made all sections ('people', 'bots', and 'companies') optional as a
particular config can contain any subset of these sections.

Finally, added handling of empty entries (accounts) in a section with proper
error reporting.