### PR TITLE
Removed Chris Hupman as IBM contributor

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -412,13 +412,6 @@ companies:
       - name: Susan Malaika
         email: malaika@us.ibm.com
         github: sumalaika
-      - name: Chris Hupman
-        email: chupman@us.ibm.com
-        github: chupman
-      # Default name/email used for GitHub merge commits in the past.
-      - name: chupman
-        email: chupman@us.ibm.com
-        github: chupman
       - name: Yihong Wang
         email: yh.wang@ibm.com
         github: yhwang


### PR DESCRIPTION
Signed-off-by: Jason Plurad <pluradj@us.ibm.com>