### PR TITLE
Remove Flux CCLA as the company was shut down

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -224,13 +224,6 @@ companies:
         email: chris.pounds@experoinc.com
         github: chrislbs
 
-  - name: Flux
-    people:
-      # CLA Manager
-      - name: Michael Carrier
-        email: michael@flux.io
-        github: FluxMcarrier
-
   - name: G DATA
     people:
       # CLA Manager


### PR DESCRIPTION
https://archpaper.com/2018/02/flux-to-shut-down/

FYI, @FluxMcarrier — if you'd like to continue contributing to JanusGraph, please sign an ICLA or ask your current employer to sign a CCLA via the new electronic LF EasyCLA process: https://lfcla.com/