### PR TITLE
Remove @amcp from Amazon CCLA as he changed jobs

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -133,17 +133,6 @@ companies:
       - name: Brandi Duffy
         email: brandis@amazon.com
         github: brandis
-      - name: Alexander Patrikalakis
-        email: amcp@amazon.com
-        github: amcp
-      # Previous email address used while working in Japan.
-      - name: Alexander Patrikalakis
-        email: amcp@amazon.co.jp
-        github: amcp
-      # Default email used for merges via GitHub web UI.
-      - name: Alexander Patrikalakis
-        email: amcp@mit.edu
-        github: amcp
       - name: Michael Rodaitis
         email: rodaitis@amazon.com
         github: mrodaitis


### PR DESCRIPTION
@amcp — if you're interested in contributing to JanusGraph, please ask your new employer to sign the CCLA via the new electronic LF CLA process: https://corporate.lfcla.com .

/cc: @hyandell and @brandis (FYI) since we're removing one of your ex-employees from your CCLA. Also, I'll be in touch with you separately by email about migrating your CCLA to the new electronic LF CLA process.