### PR TITLE
Remove VladimirBogomolov from offline ICLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -97,9 +97,6 @@ people:
   - name: Steffen Winandy
     email: stewin19@gmail.com
     github: StefWin
-  - name: Vladimir Bogomolov
-    email: vladimir.bogomoloff@gmail.com
-    github: VladimirBogomolov
   - name: Zheng Wang
     email: zhengwang1990@foxmail.com
     github: wangzheng90


### PR DESCRIPTION
This developer has already signed the LF EasyCLA, as can be evidenced in
https://github.com/JanusGraph/janusgraph/pull/1973

Merging this PR will switch the @janusgraph-bot managed CLA labels from
`[cla: yes]` to `[cla: external]` and we will rely on EasyCLA check
going forward for this developer's PRs.

---

/cc: @VladimirBogomolov (FYI, no action needed, since you've already signed the LF EasyCLA)