### PR TITLE
Remove Hortonworks CCLA as it merged with Cloudera

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -282,15 +282,6 @@ companies:
         email: jyothish@grakn.ai
         github: jyosoman
 
-  - name: Hortonworks
-    people:
-      - name: Alan F. Gates
-        email: alanfgates@gmail.com
-        github: alanfgates
-      - name: Simon Elliston Ball
-        email: simon@simonellistonball.com
-        github: simonellistonball
-
   - name: Huawei
     people:
       # CLA Manager


### PR DESCRIPTION
Hortonworks merged with Cloudera, but the name of the combined company
is "Cloudera" so Hortonworks (the brand name) has been retired.
Additionally, https://hortonworks.com redirects to https://cloudera.com,
which also suggests that the old name is no longer being used.

Thus, we need to remove the Hortonworks CCLA as it is no longer in
force, and if folks from the combined Cloudera/Hortonworks entity want
to contribute to JanusGraph, they will need to have Cloudera sign a new
CCLA, which might as well be done via the new electronic LF EasyCLA
process rather than the old-style process.

---

/cc: @alanfgates, @simonellistonball (FYI)