### PR TITLE
Remove @mad from the offline ICLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -70,9 +70,6 @@ people:
   - name: Olivier Binda
     email: olivier.binda@wanadoo.fr
     github: Lakedaemon
-  - name: Pavel Ershov
-    email: owner.mad.epa@gmail.com
-    github: mad
   - name: Prithvi Nambiar
     email: prithvinambiar@gmail.com
     github: prithvinambiar


### PR DESCRIPTION
We are migrating from the offline CLA process to the electronic LF
EasyCLA process, and @mad has already signed the LF EasyCLA, as can be
seen on: https://github.com/JanusGraph/janusgraph/pull/1977

Merging this PR will switch the @janusgraph-bot managed CLA labels from
`[cla: yes]` to `[cla: external]` and we will rely on EasyCLA check
going forward for this developer's PRs.