### PR TITLE
Migrate @porunov from offline ICLA to LF EasyCLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -68,9 +68,6 @@ people:
   - name: Mike Sager
     email: mike@mikesager.name
     github: mikesager
-  - name: Oleksandr Porunov
-    email: alexandr.porunov@gmail.com
-    github: porunov
   - name: Olivier Binda
     email: olivier.binda@wanadoo.fr
     github: Lakedaemon


### PR DESCRIPTION
This user has already signed the LF EasyCLA as evidenced in many recent PRs, so
we can switch to LF EasyCLA going forward.