### PR TITLE
Migrate Informatica to electronic EasyCLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -335,13 +335,6 @@ companies:
         email: erin.cornett@ibm.com
         github: erinc1915
 
-  - name: Informatica
-    people:
-      # CLA manager
-      - name: Mike Beaubien
-        email: mbbeaubi@umich.edu
-        github: mbbeaubi
-
   - name: Linkurious
     people:
       # CLA Manager


### PR DESCRIPTION
Per PR https://github.com/JanusGraph/janusgraph/pull/2137, Informatica signed
the electronic CCLA via EasyCLA, so we can remove this manually-managed entry.

@mbbeaubi — please confirm you're OK with managing your CLA via EasyCLA moving forward.