### PR TITLE
Migrate YevIgn to LF EasyCLA

### DIFF
--- a/CLA_SIGNERS.yaml
+++ b/CLA_SIGNERS.yaml
@@ -43,13 +43,6 @@ people:
   - name: Dylan Bethune-Waddell
     email: dylan.bethune.waddell@mail.utoronto.ca
     github: dylanht
-  - name: Evgenii Ignatev
-    email: yevgeniy.ignatyev@gmail.com
-    github: YevIgn
-  # Previous spelling of developer's name
-  - name: Evgeniy Ignatiev
-    email: yevgeniy.ignatyev@gmail.com
-    github: YevIgn
   - name: Filippo Balicchia
     email: fbalicchia@gmail.com
     github: fbalicchia


### PR DESCRIPTION
As per PR https://github.com/JanusGraph/janusgraph/pull/2173, @YevIgn has signed
the LF EasyCLA, so we no longer need to keep the CLA record in this config.